### PR TITLE
Implement interactive waterhole hover descriptions

### DIFF
--- a/Assets/Scripts/Waterholes/WaterholeHoverRaycaster.cs
+++ b/Assets/Scripts/Waterholes/WaterholeHoverRaycaster.cs
@@ -1,0 +1,117 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class WaterholeHoverRaycaster : MonoBehaviour
+{
+    [Header("Raycast Settings")]
+    [SerializeField] private Camera mainCamera;
+    [SerializeField] private float rayDistance = 1000f;
+
+    [Header("Cursor Settings")]
+    [SerializeField] private bool hideCursorOnHover = true;
+
+    private WaterholeHoverTarget currentTarget;
+    private bool isHoveringWaterhole;
+
+    private void Start()
+    {
+        if (mainCamera == null)
+        {
+            mainCamera = Camera.main;
+        }
+
+        ShowCursor();
+    }
+
+    private void Update()
+    {
+        CheckHoverTarget();
+    }
+
+    private void CheckHoverTarget()
+    {
+        if (mainCamera == null || Mouse.current == null)
+        {
+            ClearCurrentTarget();
+            ShowCursor();
+            return;
+        }
+
+        Vector2 mousePosition = Mouse.current.position.ReadValue();
+
+        Ray ray = mainCamera.ScreenPointToRay(mousePosition);
+
+        if (Physics.Raycast(ray, out RaycastHit hitInfo, rayDistance))
+        {
+            WaterholeHoverTarget target = hitInfo.collider.GetComponent<WaterholeHoverTarget>();
+
+            if (target != null)
+            {
+                isHoveringWaterhole = true;
+
+                if (currentTarget != target)
+                {
+                    ClearCurrentTarget();
+
+                    currentTarget = target;
+                    currentTarget.HoverEnter();
+                }
+
+                HideCursor();
+                return;
+            }
+        }
+
+        isHoveringWaterhole = false;
+        ClearCurrentTarget();
+        ShowCursor();
+    }
+
+    private void ClearCurrentTarget()
+    {
+        if (currentTarget != null)
+        {
+            currentTarget.HoverExit();
+            currentTarget = null;
+        }
+
+        if (WaterholeTooltipManager.Instance != null)
+        {
+            WaterholeTooltipManager.Instance.HideTooltip();
+        }
+    }
+
+    private void HideCursor()
+    {
+        if (!hideCursorOnHover)
+        {
+            return;
+        }
+
+        Cursor.visible = false;
+        Cursor.lockState = CursorLockMode.Confined;
+    }
+
+    private void ShowCursor()
+    {
+        Cursor.visible = true;
+        Cursor.lockState = CursorLockMode.None;
+    }
+
+    private void OnDisable()
+    {
+        ShowCursor();
+    }
+
+    private void OnApplicationFocus(bool hasFocus)
+    {
+        if (!hasFocus)
+        {
+            ShowCursor();
+        }
+        else if (isHoveringWaterhole)
+        {
+            HideCursor();
+        }
+    }
+}

--- a/Assets/Scripts/Waterholes/WaterholeHoverTarget.cs
+++ b/Assets/Scripts/Waterholes/WaterholeHoverTarget.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+public class WaterholeHoverTarget : MonoBehaviour
+{
+    [Header("Waterhole Information")]
+    [SerializeField] private string waterholeName;
+
+    [TextArea(3, 8)]
+    [SerializeField] private string waterholeDescription;
+
+    [Header("Optional Highlight")]
+    [SerializeField] private Renderer waterholeRenderer;
+    [SerializeField] private Color normalColor = Color.white;
+    [SerializeField] private Color hoverColor = Color.yellow;
+
+    private Material waterholeMaterial;
+
+    private void Start()
+    {
+        if (waterholeRenderer == null)
+        {
+            waterholeRenderer = GetComponent<Renderer>();
+        }
+
+        if (waterholeRenderer != null)
+        {
+            waterholeMaterial = waterholeRenderer.material;
+            waterholeMaterial.color = normalColor;
+        }
+    }
+
+    public void HoverEnter()
+    {
+        if (WaterholeTooltipManager.Instance != null)
+        {
+            WaterholeTooltipManager.Instance.ShowTooltip(
+                waterholeName,
+                waterholeDescription,
+                transform.position
+            );
+        }
+
+        if (waterholeMaterial != null)
+        {
+            waterholeMaterial.color = hoverColor;
+        }
+    }
+
+    public void HoverExit()
+    {
+        if (WaterholeTooltipManager.Instance != null)
+        {
+            WaterholeTooltipManager.Instance.HideTooltip();
+        }
+
+        if (waterholeMaterial != null)
+        {
+            waterholeMaterial.color = normalColor;
+        }
+    }
+}

--- a/Assets/Scripts/Waterholes/WaterholeTooltipManager.cs
+++ b/Assets/Scripts/Waterholes/WaterholeTooltipManager.cs
@@ -1,0 +1,79 @@
+using TMPro;
+using UnityEngine;
+
+public class WaterholeTooltipManager : MonoBehaviour
+{
+    public static WaterholeTooltipManager Instance { get; private set; }
+
+    [Header("UI References")]
+    [SerializeField] private GameObject tooltipPanel;
+    [SerializeField] private TMP_Text tooltipText;
+
+    [Header("World Position Settings")]
+    [SerializeField] private Camera mainCamera;
+    [SerializeField] private Vector3 worldOffset = new Vector3(0f, 1.2f, 0f);
+
+    private RectTransform tooltipRectTransform;
+
+    private void Awake()
+    {
+        Instance = this;
+
+        if (mainCamera == null)
+        {
+            mainCamera = Camera.main;
+        }
+
+        if (tooltipPanel != null)
+        {
+            tooltipRectTransform = tooltipPanel.GetComponent<RectTransform>();
+
+            if (tooltipText == null)
+            {
+                tooltipText = tooltipPanel.GetComponentInChildren<TMP_Text>(true);
+            }
+
+            tooltipPanel.SetActive(false);
+        }
+    }
+
+    public void ShowTooltip(string waterholeName, string description, Vector3 worldPosition)
+    {
+        if (tooltipPanel == null)
+        {
+            Debug.LogWarning("Tooltip Panel is missing.");
+            return;
+        }
+
+        if (tooltipText == null)
+        {
+            tooltipText = tooltipPanel.GetComponentInChildren<TMP_Text>(true);
+        }
+
+        if (tooltipText == null)
+        {
+            Debug.LogWarning("Tooltip Text is missing.");
+            return;
+        }
+
+        if (tooltipRectTransform == null)
+        {
+            tooltipRectTransform = tooltipPanel.GetComponent<RectTransform>();
+        }
+
+        tooltipText.text = "<align=\"center\"><size=120%><b>" + waterholeName + "</b></size>\n<size=95%>" + description + "</size></align>";
+
+        Vector3 screenPosition = mainCamera.WorldToScreenPoint(worldPosition + worldOffset);
+        tooltipRectTransform.position = screenPosition;
+
+        tooltipPanel.SetActive(true);
+    }
+
+    public void HideTooltip()
+    {
+        if (tooltipPanel != null)
+        {
+            tooltipPanel.SetActive(false);
+        }
+    }
+}

--- a/Assets/Waterhole_Hover_Progress.txt
+++ b/Assets/Waterhole_Hover_Progress.txt
@@ -1,0 +1,1 @@
+Implemented interactive waterhole hover descriptions for The Storyteller Unity board game. This included invisible waterhole hover zones, tooltip popups, child-friendly waterhole names and descriptions, improved tooltip styling, and cursor hiding behaviour during hover interaction.


### PR DESCRIPTION
This PR documents my Unity contribution for The Storyteller project.

The completed work includes:
- Interactive hover descriptions for waterholes on the board.
- Invisible waterhole hover zones.
- Tooltip popups with child-friendly waterhole names and descriptions.
- Improved tooltip styling.
- Cursor hiding when clicked behavior during hover interaction.
- Testing of the feature in Unity.

<img width="1920" height="1050" alt="Screenshot 2026-05-15 114712" src="https://github.com/user-attachments/assets/766d5543-7151-4b27-83de-20f7481525f1" />
<img width="1920" height="1050" alt="Screenshot 2026-05-15 115109" src="https://github.com/user-attachments/assets/4c8e777e-082c-404d-a49e-969e69819b8c" />
<img width="1920" height="1050" alt="Screenshot 2026-05-15 115701" src="https://github.com/user-attachments/assets/f886863b-2a75-4954-a305-f12665d62c9c" />

